### PR TITLE
Swipeselection

### DIFF
--- a/TheChan.xcodeproj/project.pbxproj
+++ b/TheChan.xcodeproj/project.pbxproj
@@ -584,7 +584,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = QQNTMQ5VM7;
 				INFOPLIST_FILE = TheChan/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -602,7 +601,6 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = QQNTMQ5VM7;
 				INFOPLIST_FILE = TheChan/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TheChan.xcodeproj/project.pbxproj
+++ b/TheChan.xcodeproj/project.pbxproj
@@ -584,6 +584,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = QQNTMQ5VM7;
 				INFOPLIST_FILE = TheChan/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -601,6 +602,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = QQNTMQ5VM7;
 				INFOPLIST_FILE = TheChan/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/TheChan/Base.lproj/Main.storyboard
+++ b/TheChan/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -24,7 +24,7 @@
                                 <rect key="frame" x="0.0" y="56" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Bow-fP-ph6" id="48A-QF-DeI">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="60"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="boY-Gb-e6i">
@@ -124,7 +124,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="220"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YTE-DC-USd" id="yab-nz-L3a">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="220"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="219"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="25" verticalHuggingPriority="252" horizontalCompressionResistancePriority="735" text="Subject" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oag-5v-DNr">
@@ -235,6 +235,7 @@
                                         <constraint firstItem="G0V-Fe-bKh" firstAttribute="leading" secondItem="Kih-4b-eSD" secondAttribute="trailing" constant="4" id="yhQ-aE-aag"/>
                                     </constraints>
                                 </tableViewCellContentView>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dateLabel" destination="2kg-JA-Yt2" id="SYu-zI-tf2"/>

--- a/TheChan/BoardsTableViewController.swift
+++ b/TheChan/BoardsTableViewController.swift
@@ -14,7 +14,7 @@ class BoardsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        clearsSelectionOnViewWillAppear = false         // this done manually
+        clearsSelectionOnViewWillAppear = false         // this is done manually
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false

--- a/TheChan/BoardsTableViewController.swift
+++ b/TheChan/BoardsTableViewController.swift
@@ -41,7 +41,7 @@ class BoardsTableViewController: UITableViewController {
         let selection = tableView.indexPathForSelectedRow
         if (selection != nil){
             tableView.deselectRow(at: selection!, animated: true)
-            transitionCoordinator?.notifyWhenInteractionChanges({(context) in
+            transitionCoordinator?.notifyWhenInteractionEnds({(context) in
                 if (context.isCancelled){
                     self.tableView.selectRow(at: selection, animated: false, scrollPosition: UITableViewScrollPosition.none)
                 }

--- a/TheChan/BoardsTableViewController.swift
+++ b/TheChan/BoardsTableViewController.swift
@@ -14,6 +14,7 @@ class BoardsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        clearsSelectionOnViewWillAppear = false         // this done manually
 
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
@@ -31,6 +32,20 @@ class BoardsTableViewController: UITableViewController {
                 self.tableView.reloadData()
                 activityView.stopAnimating()
             }
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool){
+        super.viewWillAppear(animated)
+        
+        let selection = tableView.indexPathForSelectedRow
+        if (selection != nil){
+            tableView.deselectRow(at: selection!, animated: true)
+            transitionCoordinator?.notifyWhenInteractionChanges({(context) in
+                if (context.isCancelled){
+                    self.tableView.selectRow(at: selection, animated: false, scrollPosition: UITableViewScrollPosition.none)
+                }
+            })
         }
     }
 

--- a/TheChan/ThreadsTableViewController.swift
+++ b/TheChan/ThreadsTableViewController.swift
@@ -27,7 +27,7 @@ class ThreadsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        clearsSelectionOnViewWillAppear = false         // this done manually
+        clearsSelectionOnViewWillAppear = false         // this is done manually
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = 250
         

--- a/TheChan/ThreadsTableViewController.swift
+++ b/TheChan/ThreadsTableViewController.swift
@@ -27,12 +27,27 @@ class ThreadsTableViewController: UITableViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        clearsSelectionOnViewWillAppear = false         // this done manually
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = 250
         
         refreshControl?.addTarget(self, action: #selector(ThreadsTableViewController.refresh(refreshControl:)), for: .valueChanged)
         
         loadPage(currentPage)
+    }
+    
+    override func viewWillAppear(_ animated: Bool){
+        super.viewWillAppear(animated)
+        
+        let selection = tableView.indexPathForSelectedRow
+        if (selection != nil){
+            tableView.deselectRow(at: selection!, animated: true)
+            transitionCoordinator?.notifyWhenInteractionChanges({(context) in
+                if (context.isCancelled){
+                    self.tableView.selectRow(at: selection, animated: false, scrollPosition: UITableViewScrollPosition.none)
+                }
+            })
+        }
     }
     
     func refresh(refreshControl: UIRefreshControl) {

--- a/TheChan/ThreadsTableViewController.swift
+++ b/TheChan/ThreadsTableViewController.swift
@@ -42,7 +42,7 @@ class ThreadsTableViewController: UITableViewController {
         let selection = tableView.indexPathForSelectedRow
         if (selection != nil){
             tableView.deselectRow(at: selection!, animated: true)
-            transitionCoordinator?.notifyWhenInteractionChanges({(context) in
+            transitionCoordinator?.notifyWhenInteractionEnds({(context) in
                 if (context.isCancelled){
                     self.tableView.selectRow(at: selection, animated: false, scrollPosition: UITableViewScrollPosition.none)
                 }


### PR DESCRIPTION
Починил выделение ячеек при свайпе назад. Ранее оно не пропадало, если сдвигать экран с нормальной скоростью (по слоупочному, постепенно угасая, таки пропадало). Решение, впрочем, стырил отсюда — http://blog.supertop.co/post/80781694515/viewmightappear
Используется ныне депрекейтед метод notifyWhenInteractionEnds, вместо notifyWhenInteractionChanges, потому что последний лишь в десятке появился. Эта часть нужна для того, чтобы ячейка осталась выделенной при отмене свайпа на пол пути.

Ещё подправил фон ячеек тредов на доске (с белого на чёрный, как у ячеек досок), иначе цвет выделения был развёрнут, на пике показал.
![screen shot 2016-11-18 at 05 31 36](https://cloud.githubusercontent.com/assets/8090867/20408978/cbe129f0-ad52-11e6-9efd-6d1baa724365.png)
Вообще, в сторибоарде ещё и высоты какие-то почему-то поменялись на 1 пиксель, так что его можешь проигнорить и сам это сделать, мало ли что.

