### PR TITLE
Webm support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,6 +1,12 @@
 platform :ios, '10.0'
 use_frameworks!
 
+source 'https://github.com/CocoaPods/Specs.git'
+
+# This line is needed until OGVKit is fully published to CocoaPods
+# Remove once packages published:
+source 'https://github.com/brion/OGVKit-Specs.git'
+
 target 'TheChan' do
     pod 'Alamofire', '~> 4.0'
     pod 'Kingfisher'
@@ -8,4 +14,13 @@ target 'TheChan' do
     pod 'Kanna'
     pod 'RealmSwift'
     pod 'IQKeyboardManagerSwift'
+    pod 'OGVKit', '0.5pre'
+end
+
+post_install do |installer|
+    installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+            config.build_settings['ENABLE_BITCODE'] = 'NO'
+        end
+    end
 end

--- a/TheChan.xcodeproj/project.pbxproj
+++ b/TheChan.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6369DB261DE0CA6F00139F07 /* WebmViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6369DB251DE0CA6F00139F07 /* WebmViewController.swift */; };
 		6B8AC87277C8CE01CD0E211F /* Pods_TheChan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BE570531390E34C301000CA6 /* Pods_TheChan.framework */; };
 		92269B4D1DCF4EAC001235E9 /* ThreadStateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92269B4B1DCF4EAC001235E9 /* ThreadStateViewController.swift */; };
 		92269B4E1DCF4EAC001235E9 /* ThreadStateViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 92269B4C1DCF4EAC001235E9 /* ThreadStateViewController.xib */; };
@@ -55,6 +56,7 @@
 
 /* Begin PBXFileReference section */
 		2CFE6C7DCB3189918F28A90F /* Pods-TheChan.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheChan.release.xcconfig"; path = "Pods/Target Support Files/Pods-TheChan/Pods-TheChan.release.xcconfig"; sourceTree = "<group>"; };
+		6369DB251DE0CA6F00139F07 /* WebmViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebmViewController.swift; sourceTree = "<group>"; };
 		7742CA22650DDF071EDD171B /* Pods-TheChan.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TheChan.debug.xcconfig"; path = "Pods/Target Support Files/Pods-TheChan/Pods-TheChan.debug.xcconfig"; sourceTree = "<group>"; };
 		92269B4B1DCF4EAC001235E9 /* ThreadStateViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadStateViewController.swift; sourceTree = "<group>"; };
 		92269B4C1DCF4EAC001235E9 /* ThreadStateViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThreadStateViewController.xib; sourceTree = "<group>"; };
@@ -221,6 +223,7 @@
 				92289B5C1DB369CB00F5BE09 /* ThreadTableViewController.swift */,
 				92908A161DD7728B00B89A7F /* FavoriteThreadsCollectionViewController.swift */,
 				92ED146B1DDB83150009D8EC /* PostingViewController.swift */,
+				6369DB251DE0CA6F00139F07 /* WebmViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -290,7 +293,7 @@
 				TargetAttributes = {
 					92A0B9BF1DAEC304005D743F = {
 						CreatedOnToolsVersion = 8.0;
-						DevelopmentTeam = QQNTMQ5VM7;
+						DevelopmentTeam = DR3K59SZNX;
 						ProvisioningStyle = Automatic;
 					};
 					92A0B9D31DAEC304005D743F = {
@@ -398,6 +401,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				92304F271DDE140500240505 /* ImageCaptcha.swift in Sources */,
+				6369DB261DE0CA6F00139F07 /* WebmViewController.swift in Sources */,
 				92A0B9E91DAEC71D005D743F /* BoardsGroup.swift in Sources */,
 				92908A0F1DD6627200B89A7F /* FavoriteThread.swift in Sources */,
 				92A0B9EB1DAEC7B5005D743F /* Facade.swift in Sources */,
@@ -510,6 +514,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -526,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -563,6 +568,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -573,7 +579,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -590,10 +596,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = QQNTMQ5VM7;
+				DEVELOPMENT_TEAM = DR3K59SZNX;
 				INFOPLIST_FILE = TheChan/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
+				PRODUCT_BUNDLE_IDENTIFIER = io.test.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};
@@ -607,10 +613,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = QQNTMQ5VM7;
+				DEVELOPMENT_TEAM = DR3K59SZNX;
 				INFOPLIST_FILE = TheChan/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.acedened.TheChan;
+				PRODUCT_BUNDLE_IDENTIFIER = io.test.TheChan;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 3.0;
 			};

--- a/TheChan/Base.lproj/Main.storyboard
+++ b/TheChan/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -21,10 +21,10 @@
                         <color key="separatorColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="0.0" reuseIdentifier="BoardTableViewCell" rowHeight="60" id="Bow-fP-ph6" customClass="BoardTableViewCell" customModule="TheChan" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="320" height="60"/>
+                                <rect key="frame" x="0.0" y="56" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Bow-fP-ph6" id="48A-QF-DeI">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="boY-Gb-e6i">
@@ -124,7 +124,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="220"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YTE-DC-USd" id="yab-nz-L3a">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="219.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="219"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="25" verticalHuggingPriority="252" horizontalCompressionResistancePriority="735" text="Subject" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oag-5v-DNr">
@@ -152,7 +152,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p2K-sM-4bK">
-                                            <rect key="frame" x="159.5" y="190" width="1" height="21"/>
+                                            <rect key="frame" x="160" y="190" width="1" height="21"/>
                                             <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="JO5-9e-BEz"/>
@@ -160,25 +160,25 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6qu-z3-9xj">
-                                            <rect key="frame" x="106.5" y="190" width="43" height="21"/>
+                                            <rect key="frame" x="107" y="190" width="43" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="FILES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G0V-Fe-bKh">
-                                            <rect key="frame" x="190.5" y="190" width="121.5" height="21"/>
+                                            <rect key="frame" x="191" y="190" width="121" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gJ7-g6-p54">
-                                            <rect key="frame" x="8" y="190" width="94.5" height="21"/>
+                                            <rect key="frame" x="8" y="190" width="95" height="21"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kih-4b-eSD">
-                                            <rect key="frame" x="170.5" y="190" width="16" height="21"/>
+                                            <rect key="frame" x="171" y="190" width="16" height="21"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
@@ -321,7 +321,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="222"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kk5-eU-lFz" id="bBT-NE-Fop">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="221.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="221"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Fzv-Bg-ZL7">
@@ -771,7 +771,7 @@
                     <tabBarItem key="tabBarItem" title="Boards" image="boardsIcon" id="9Oy-op-xsZ"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="Dl7-ng-ysS">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" id="Dl7-ng-ysS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -795,7 +795,7 @@
                     <tabBarItem key="tabBarItem" systemItem="favorites" id="Ajo-q9-Iu9"/>
                     <toolbarItems/>
                     <nil key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="Qnw-MD-zpG">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" id="Qnw-MD-zpG">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -928,7 +928,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="whV-dW-GcX" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" systemItem="recents" id="wz1-CF-L2p"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="zLb-eT-Ib9">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="zLb-eT-Ib9">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/TheChan/Base.lproj/Main.storyboard
+++ b/TheChan/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="JbK-Zd-IUc">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -21,10 +21,10 @@
                         <color key="separatorColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="0.0" reuseIdentifier="BoardTableViewCell" rowHeight="60" id="Bow-fP-ph6" customClass="BoardTableViewCell" customModule="TheChan" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="56" width="320" height="60"/>
+                                <rect key="frame" x="0.0" y="55.5" width="320" height="60"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Bow-fP-ph6" id="48A-QF-DeI">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="59.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="boY-Gb-e6i">
@@ -124,7 +124,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="220"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="YTE-DC-USd" id="yab-nz-L3a">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="219"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="219.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="25" verticalHuggingPriority="252" horizontalCompressionResistancePriority="735" text="Subject" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oag-5v-DNr">
@@ -152,7 +152,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="p2K-sM-4bK">
-                                            <rect key="frame" x="160" y="190" width="1" height="21"/>
+                                            <rect key="frame" x="159.5" y="190" width="1" height="21"/>
                                             <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="JO5-9e-BEz"/>
@@ -160,25 +160,25 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="POSTS" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6qu-z3-9xj">
-                                            <rect key="frame" x="107" y="190" width="43" height="21"/>
+                                            <rect key="frame" x="106.5" y="190" width="43" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="FILES" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G0V-Fe-bKh">
-                                            <rect key="frame" x="191" y="190" width="121" height="21"/>
+                                            <rect key="frame" x="190.5" y="190" width="121.5" height="21"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gJ7-g6-p54">
-                                            <rect key="frame" x="8" y="190" width="95" height="21"/>
+                                            <rect key="frame" x="8" y="190" width="94.5" height="21"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="10" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kih-4b-eSD">
-                                            <rect key="frame" x="171" y="190" width="16" height="21"/>
+                                            <rect key="frame" x="170.5" y="190" width="16" height="21"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="13"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
@@ -321,7 +321,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="222"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="kk5-eU-lFz" id="bBT-NE-Fop">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="221"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="221.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Fzv-Bg-ZL7">
@@ -771,7 +771,7 @@
                     <tabBarItem key="tabBarItem" title="Boards" image="boardsIcon" id="9Oy-op-xsZ"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" barStyle="black" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" id="Dl7-ng-ysS">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="Dl7-ng-ysS">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -795,7 +795,7 @@
                     <tabBarItem key="tabBarItem" systemItem="favorites" id="Ajo-q9-Iu9"/>
                     <toolbarItems/>
                     <nil key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" barStyle="black" id="Qnw-MD-zpG">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" barStyle="black" id="Qnw-MD-zpG">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -928,7 +928,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="whV-dW-GcX" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" systemItem="recents" id="wz1-CF-L2p"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="zLb-eT-Ib9">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="zLb-eT-Ib9">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -9,7 +9,6 @@
 import UIKit
 import MWPhotoBrowser
 import RealmSwift
-import OGVKit
 
 class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import MWPhotoBrowser
 import RealmSwift
+import OGVKit
 
 class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     
@@ -238,6 +239,14 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     }
     
     func onAttachmentSelected(attachment: Attachment) {
+        if (attachment.type == .video){
+            let videoController = WebmViewController(url: attachment.url)
+//            videoController.setVideo(attachment.url)
+
+            self.navigationController!.pushViewController(videoController, animated: true)
+            return
+        }
+        
         allAttachments = posts.flatMap { post in post.attachments }
         allFiles = allAttachments.map { attachment in
             attachment.type == .image ? MWPhoto(url: attachment.url) : MWPhoto(videoURL: attachment.url)

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -240,8 +240,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     func onAttachmentSelected(attachment: Attachment) {
         if (attachment.type == .video){
             let videoController = WebmViewController(url: attachment.url)
-//            videoController.setVideo(attachment.url)
-
+            
             self.navigationController!.pushViewController(videoController, animated: true)
             return
         }

--- a/TheChan/WebmViewController.swift
+++ b/TheChan/WebmViewController.swift
@@ -1,0 +1,108 @@
+//
+//  WebmView.swift
+//  TheChan
+//
+//  Created by Sergey Korabanov on 20/11/16.
+//  Copyright © 2016 ACEDENED Software. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import OGVKit
+
+class WebmViewController: UIViewController, OGVPlayerDelegate {
+  
+    override var prefersStatusBarHidden : Bool {
+        return true
+    }
+    private var videoUrl: URL!
+    private var player: OGVPlayerView!
+    private var autoplay: Bool!
+    private var loop: Bool! = false
+    
+    convenience init(url: URL, _ autoplay: Bool = true) {
+        self.init(nibName: nil, bundle: nil)
+        self.videoUrl = url
+        self.autoplay = autoplay
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.navigationController?.setNavigationBarHidden(true, animated: false)
+        self.setNeedsStatusBarAppearanceUpdate()
+        
+        player = OGVPlayerView.init(frame: self.view.bounds)
+        player.delegate = self
+        self.view.addSubview(player)
+        
+        player.sourceURL = videoUrl
+
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        if (self.autoplay!){
+            player.play()
+            self.hideControls()
+        }
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        coordinator.animate(alongsideTransition: nil, completion: {_ in
+            let rect = CGRect.init(origin: CGPoint.init(x: 0, y: 0), size: size)
+            self.player.frameView.frame = rect
+        })
+        
+        super.viewWillTransition(to: size, with: coordinator)
+    }
+
+    func setVideo(_ url: URL, _ autoplay: Bool = false){
+        videoUrl = url
+        self.autoplay = autoplay
+    }
+    
+    func hideControls(){
+        // copy-paste of a method stupidly made private
+        UIView.animate(withDuration: 0.5, animations: {
+            self.player.controlBar.alpha = 0
+        })
+    }
+    
+    func showControls(){
+        // copy-paste of a method stupidly made private
+        UIView.animate(withDuration: 0.5, animations: {
+            self.player.controlBar.alpha = 1
+        })
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        player.pause()
+    }
+    
+    func ogvPlayerDidPlay(_ sender: OGVPlayerView!) {
+        if (self.autoplay!){
+            self.hideControls()
+            self.navigationController?.setNavigationBarHidden(true, animated: true)
+            self.autoplay = false               // So that controls are auto-hidden only the first time video plays
+        }
+    }
+    
+    func ogvPlayerDidEnd(_ sender: OGVPlayerView!) {
+        // workaround to replay the video without closing the view/controller
+        self.autoplay = self.loop
+        player.sourceURL = videoUrl
+    }
+    
+    func ogvPlayerControlsWillShow(_ sender: OGVPlayerView!) {
+        self.navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+    
+    func ogvPlayerControlsWillHide(_ sender: OGVPlayerView!) {
+        self.navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+    
+    func ogvPlayerDidLoadMetadata(_ sender: OGVPlayerView!) {
+    }
+}

--- a/TheChan/WebmViewController.swift
+++ b/TheChan/WebmViewController.swift
@@ -56,11 +56,6 @@ class WebmViewController: UIViewController, OGVPlayerDelegate {
         
         super.viewWillTransition(to: size, with: coordinator)
     }
-
-    func setVideo(_ url: URL, _ autoplay: Bool = false){
-        videoUrl = url
-        self.autoplay = autoplay
-    }
     
     func hideControls(){
         // copy-paste of a method stupidly made private
@@ -91,6 +86,7 @@ class WebmViewController: UIViewController, OGVPlayerDelegate {
     
     func ogvPlayerDidEnd(_ sender: OGVPlayerView!) {
         // workaround to replay the video without closing the view/controller
+        // this still however reloads the video, not bandwidth-friendly.
         self.autoplay = self.loop
         player.sourceURL = videoUrl
     }

--- a/TheChan/WebmViewController.swift
+++ b/TheChan/WebmViewController.swift
@@ -85,7 +85,7 @@ class WebmViewController: UIViewController, OGVPlayerDelegate {
         if (self.autoplay!){
             self.hideControls()
             self.navigationController?.setNavigationBarHidden(true, animated: true)
-            self.autoplay = false               // So that controls are auto-hidden only the first time video plays
+            self.autoplay = false               // So that controls are auto-hidden only the first time the video plays
         }
     }
     


### PR DESCRIPTION
Добавил возможность вебмки смотреть!

Сделано пока аналогично 2ch-browser'у в том плане, что на каждую вебмку свой контроллер открывается, а не как с фото у тебя сделано, где целый список. Потом можно попробовать как-то интегрировать видео-плеер в этот фото-браузер, если возможно.

Используется OGVKit, некий обрубок от VLCKit'а, поддерживающий, собственно, только ogg/vorbis, сделанный википедией для своего приложения. Не хотелось тащить громоздкий влц, но чёрт его знает, возможно и придётся в итоге.

Есть несколько проблем, которые, беря во внимание происхождение ogvkit'а, полагаю, в vlc тоже присутствуют:
1. видео нельзя было проиграть заново после окончания (замечено и в 2ch-browser'е, где vlc используется). Пришлось небольшой костылик сделать со сбросом url'а видео, то есть просто заново перезагружать. Как следствие, вместо последнего или первого кадра видео просто чёрный экран, потому что сама загрузка данных не начинается (это-то хорошо, в принципе).
2. Перемотка через хедер Range:, то есть каждый раз всё качается. Видимо, именно поэтому и нет возможности просмотра заново — данные нигде не хранятся.
3. По крайней мере несколько вебм'ок проигрывали только аудио. в 2ch-browser'е не затестил, так как удалил уже к тому времени.
4. Звуком управлять нельзя, даже в беззвучном режиме он есть.
5. Для использования libvpx _на телефоне_ приходится отключать некий bitcode. В симуляторе всё ок.

Из моего:
6. Переход в лендскейп какой-то уродский: сначала видео куда-то в угол съезжает, а в конце анимации уже вызывается мой метод, меняющий фрейм у плеера. Как иначе сделать что-то не представляю, этот viewWillTransitionToSize непонятный какой-то. При этом переход обратно в портретный режим более-менее нормально выглядит, хотя бы за экран видео не уезжает. Потом ещё поиграюсь.