### PR TITLE
more navigation stuff

### DIFF
--- a/TheChan/BoardsTableViewController.swift
+++ b/TheChan/BoardsTableViewController.swift
@@ -33,8 +33,6 @@ class BoardsTableViewController: UITableViewController, UIGestureRecognizerDeleg
                 activityView.stopAnimating()
             }
         }
-        
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     override func viewWillAppear(_ animated: Bool){
@@ -49,6 +47,8 @@ class BoardsTableViewController: UITableViewController, UIGestureRecognizerDeleg
                 }
             }
         }
+        
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {

--- a/TheChan/BoardsTableViewController.swift
+++ b/TheChan/BoardsTableViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class BoardsTableViewController: UITableViewController, UIGestureRecognizerDelegate {
+class BoardsTableViewController: UITableViewController {
 
     var groups = [BoardsGroup]()
     
@@ -47,12 +47,6 @@ class BoardsTableViewController: UITableViewController, UIGestureRecognizerDeleg
                 }
             }
         }
-        
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
-    }
-    
-    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return (self.navigationController?.viewControllers.count)! > 1
     }
 
     override func didReceiveMemoryWarning() {

--- a/TheChan/FavoriteThreadsCollectionViewController.swift
+++ b/TheChan/FavoriteThreadsCollectionViewController.swift
@@ -12,7 +12,7 @@ import RealmSwift
 private let reuseIdentifier = "FavoriteThreadCollectionViewCell"
 private let minItemWidth = CGFloat(150.0)
 
-class FavoriteThreadsCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+class FavoriteThreadsCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate {
 
     private var uiRealm: Realm? = nil
     private var notificationToken: NotificationToken? = nil
@@ -45,6 +45,12 @@ class FavoriteThreadsCollectionViewController: UICollectionViewController, UICol
                 break
             }
         }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     deinit {

--- a/TheChan/FavoriteThreadsCollectionViewController.swift
+++ b/TheChan/FavoriteThreadsCollectionViewController.swift
@@ -12,7 +12,7 @@ import RealmSwift
 private let reuseIdentifier = "FavoriteThreadCollectionViewCell"
 private let minItemWidth = CGFloat(150.0)
 
-class FavoriteThreadsCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout, UIGestureRecognizerDelegate {
+class FavoriteThreadsCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
 
     private var uiRealm: Realm? = nil
     private var notificationToken: NotificationToken? = nil
@@ -45,12 +45,6 @@ class FavoriteThreadsCollectionViewController: UICollectionViewController, UICol
                 break
             }
         }
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
     
     deinit {

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -30,8 +30,9 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
     private let stateController = ThreadStateViewController()
     private let uiRealm: Realm = RealmInstance.ui
     private var favoriteThread: FavoriteThread? = nil
-    private var isLoading: Bool! = false
-    private var needsScrollToBottom: Bool! = false
+    
+    private var isLoading = false
+    private var needsScrollToBottom = false
     private var gestureRecognizerDelegate: UIGestureRecognizerDelegate!
     
     private var isInFavorites = false {
@@ -76,7 +77,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
             self.stopLoading(indicator: self.progressIndicator)
             self.tableView.reloadData()
             
-            if self.needsScrollToBottom! {
+            if self.needsScrollToBottom {
                 self.scrollToBottom()
             }
             self.needsScrollToBottom = false
@@ -86,26 +87,37 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
-        gestureRecognizerDelegate = self.navigationController!.interactivePopGestureRecognizer!.delegate!
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+        gestureRecognizerDelegate = navigationController!.interactivePopGestureRecognizer!.delegate!
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
         navigationController?.hidesBarsOnSwipe = true
         navigationController?.setToolbarHidden(false, animated: false)
+        navigationItem.setHidesBackButton(false, animated: true)
         fixStatusBarScroll(view: self.view)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        navigationController?.interactivePopGestureRecognizer?.delegate = gestureRecognizerDelegate
         navigationController?.hidesBarsOnSwipe = false
         navigationController?.setToolbarHidden(true, animated: true)
         navigationController?.setNavigationBarHidden(false, animated: true)
+        navigationItem.setHidesBackButton(true, animated: true)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
         
-        self.navigationController?.interactivePopGestureRecognizer?.delegate = gestureRecognizerDelegate
+        navigationItem.hidesBackButton = false
     }
     
     func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        return !isLoading!          // lol syntax
+        return !isLoading
     }
 
     
@@ -367,7 +379,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
     }
     
     @IBAction func goDownButtonTapped(_ sender: Any) {
-        if isLoading! {
+        if isLoading {
             needsScrollToBottom = true
         }
         scrollToBottom()

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import MWPhotoBrowser
 import RealmSwift
 
-class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
+class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, UIGestureRecognizerDelegate {
     
     private enum ThreadRefreshingResult {
         case success, failure
@@ -32,6 +32,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     private var favoriteThread: FavoriteThread? = nil
     private var isLoading: Bool! = false
     private var needsScrollToBottom: Bool! = false
+    private var gestureRecognizerDelegate: UIGestureRecognizerDelegate!
     
     private var isInFavorites = false {
         didSet {
@@ -81,6 +82,13 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
             self.needsScrollToBottom = false
         }
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        gestureRecognizerDelegate = self.navigationController!.interactivePopGestureRecognizer!.delegate!
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+    }
 
     override func viewDidAppear(_ animated: Bool) {
         navigationController?.hidesBarsOnSwipe = true
@@ -91,10 +99,15 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         navigationController?.hidesBarsOnSwipe = false
         navigationController?.setToolbarHidden(true, animated: true)
-//        if (navigationController?.isNavigationBarHidden)! {
-            navigationController?.setNavigationBarHidden(false, animated: true)
-//        }
+        navigationController?.setNavigationBarHidden(false, animated: true)
+        
+        self.navigationController?.interactivePopGestureRecognizer?.delegate = gestureRecognizerDelegate
     }
+    
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return !isLoading!          // lol syntax
+    }
+
     
     func fixStatusBarScroll(view: UIView){
         for subview in view.subviews {

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -30,6 +30,8 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     private let stateController = ThreadStateViewController()
     private let uiRealm: Realm = RealmInstance.ui
     private var favoriteThread: FavoriteThread? = nil
+    private var isLoading: Bool! = false
+    private var needsScrollToBottom: Bool! = false
     
     private var isInFavorites = false {
         didSet {
@@ -38,7 +40,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     }
     
     override var prefersStatusBarHidden: Bool {
-        return navigationController?.isNavigationBarHidden == true
+        return (navigationController?.isNavigationBarHidden)!
     }
     
     override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
@@ -60,7 +62,9 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
         
         self.titleButton.setTitle(self.getTitleFrom(boardId: info.boardId, threadNumber: info.threadNumber), for: .normal)
         startLoading(indicator: progressIndicator)
+        isLoading = true
         Facade.loadThread(boardId: info.boardId, number: info.threadNumber) { posts in
+            self.isLoading = false
             if let posts = posts {
                 self.titleButton.setTitle(self.getTitleFrom(post: posts.first!), for: .normal)
                 self.posts += posts
@@ -70,6 +74,11 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
             
             self.stopLoading(indicator: self.progressIndicator)
             self.tableView.reloadData()
+            
+            if self.needsScrollToBottom! && self.posts.count > 0 {
+                self.scrollToBottom()
+            }
+            self.needsScrollToBottom = false
         }
     }
 
@@ -82,9 +91,9 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
     override func viewWillDisappear(_ animated: Bool) {
         navigationController?.hidesBarsOnSwipe = false
         navigationController?.setToolbarHidden(true, animated: true)
-        if (navigationController?.isNavigationBarHidden == true) {
+//        if (navigationController?.isNavigationBarHidden)! {
             navigationController?.setNavigationBarHidden(false, animated: true)
-        }
+//        }
     }
     
     func fixStatusBarScroll(view: UIView){
@@ -92,7 +101,7 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
             if let scrollView = subview as? UIScrollView {
                 scrollView.scrollsToTop = false
             }
-            if (subview.subviews.count > 0) {
+            if subview.subviews.count > 0 {
                 fixStatusBarScroll(view: subview)
             }
         }
@@ -333,13 +342,21 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate {
         }
     }
 
+    func scrollToBottom() {
+        let indexPath = IndexPath(row: posts.count - 1, section: 0)
+        tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+    }
+    
     @IBAction func titleTouched(_ sender: AnyObject) {
         tableView.setContentOffset(CGPoint.init(x: 0, y: 0 - tableView.contentInset.top), animated: true)
     }
     
     @IBAction func goDownButtonTapped(_ sender: Any) {
-        let indexPath = IndexPath(row: posts.count - 1, section: 0)
-        tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        if isLoading! {
+            needsScrollToBottom = true
+        } else if posts.count > 0 {
+            scrollToBottom()
+        }
     }
     
     @IBAction func favoriteButtonTapped(_ sender: UIBarButtonItem) {

--- a/TheChan/ThreadTableViewController.swift
+++ b/TheChan/ThreadTableViewController.swift
@@ -65,7 +65,6 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
         startLoading(indicator: progressIndicator)
         isLoading = true
         Facade.loadThread(boardId: info.boardId, number: info.threadNumber) { posts in
-            self.isLoading = false
             if let posts = posts {
                 self.titleButton.setTitle(self.getTitleFrom(post: posts.first!), for: .normal)
                 self.posts += posts
@@ -73,10 +72,11 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
                 self.updateThreadState(refreshingResult: .success)
             }
             
+            self.isLoading = false
             self.stopLoading(indicator: self.progressIndicator)
             self.tableView.reloadData()
             
-            if self.needsScrollToBottom! && self.posts.count > 0 {
+            if self.needsScrollToBottom! {
                 self.scrollToBottom()
             }
             self.needsScrollToBottom = false
@@ -356,8 +356,10 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
     }
 
     func scrollToBottom() {
-        let indexPath = IndexPath(row: posts.count - 1, section: 0)
-        tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        if posts.count > 0 {
+            let indexPath = IndexPath(row: posts.count - 1, section: 0)
+            tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+        }
     }
     
     @IBAction func titleTouched(_ sender: AnyObject) {
@@ -367,9 +369,8 @@ class ThreadTableViewController: UITableViewController, MWPhotoBrowserDelegate, 
     @IBAction func goDownButtonTapped(_ sender: Any) {
         if isLoading! {
             needsScrollToBottom = true
-        } else if posts.count > 0 {
-            scrollToBottom()
         }
+        scrollToBottom()
     }
     
     @IBAction func favoriteButtonTapped(_ sender: UIBarButtonItem) {

--- a/TheChan/ThreadsTableViewController.swift
+++ b/TheChan/ThreadsTableViewController.swift
@@ -50,6 +50,16 @@ class ThreadsTableViewController: UITableViewController {
         }
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.navigationItem.hidesBackButton = false
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+    }
+    
     func refresh(refreshControl: UIRefreshControl) {
         if isLoading { return }
         isRefreshing = true


### PR DESCRIPTION
Переделал фикс свайпа назад из треда, были проблемы:
1. Потерялась возможность свайпаться назад из фото браузера. 
2. Если попытаться свайпнуть назад во время прогрузки треда, то по окончании пострения массива Post'ов, всё сломается. Контроллер будет думать, что вернулся на прежний экран, но отображался тред, при этом даже без постов.

Теперь при заходе в threadViewController запоминается текущий делегат для gestureRecognizer'а и заменяется на threadViewController. При попытке свайпать во время загрузки (добавлена переменная состояния isLoading) свайп игнорируется.
При уходе с этой вьюшки возвращается запомненный, поэтому больше нигде ничего не нужно делать.


Затем, иногда нижний тулбар появлялся до загрузки треда, и при нажатии "вниз" всё крешилось. Точно так же оно крешилось и при попытке проскроллить вниз в пустом (не существующем/удалённом) треде. Решил сделать так, что если кнопка нажата при загрузке, то проскроллит вниз как только сможет. Наверное, бесполезная штука, поэтому на твоё усмотрение, но posts.count проверять надо обязательно.